### PR TITLE
Removing reference to Bifrost having stopped

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,7 @@ The backend development is focused on CQRS (Command Query Responsibility Segrega
 
 The fronted development is focused on MVVM (Model View ViewModel) for promoting better separation.
 
-Originally developed by [dolittle](http://bifrost.dolittle.com), the project was forked after
-[development stopped](http://www.ingebrigtsen.info/2016/02/11/bifrost-end-of-the-line/) in February 2016.
+Originally developed by [dolittle](http://bifrost.dolittle.com), the project was forked in February 2016.
 
 To get an idea of how the framework will help you get up and running fast, have a look here : http://vimeo.com/30971308
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -108,8 +108,7 @@ _Other changes_
 
 
 # Fork
-Originally developed by [dolittle](http://bifrost.dolittle.com), the project was forked after
-[development stopped](http://www.ingebrigtsen.info/2016/02/11/bifrost-end-of-the-line/) in February 2016.
+Originally developed by [dolittle](http://bifrost.dolittle.com), the project was forked in February 2016.
 The release notes below are adapted from http://bifrost.dolittle.com/ReleaseNotes.
 
 ## Version 1.0.0.31


### PR DESCRIPTION
In light of recent events (me picking up the maintenance of Bifrost again) - read more here: http://www.ingebrigtsen.info/2016/12/28/bifrost-getting-back-to-it/

The original post has been removed as well.

Might be worth mentioning the documentation that is being undertaken: https://dolittle.github.io/bifrost